### PR TITLE
revert: "fix: Remove testpypi as secret doesn't exist"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,5 @@ jobs:
         file_glob: true
     - name: Deploy to PyPI
       run: |
+        poetry publish -r testpypi -u "__token__" -p "${{ secrets.TEST_PYPI_TOKEN }}"
         poetry publish -u "__token__" -p "${{ secrets.PYPI_TOKEN }}"


### PR DESCRIPTION
Reverts MeltanoLabs/tap-messagebird#19

This didn't work, reverting